### PR TITLE
Implement basic floorplan parsing pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "tsx watch src/server.ts",
     "start": "tsx src/server.ts",
-    "build": "tsc -p ."
+    "build": "tsc -p .",
+    "test": "vitest run"
   },
   "dependencies": {
     "clipper-lib": "^6.4.2",
@@ -26,6 +27,7 @@
     "ts-node": "^10.9.2",
     "ts-node-dev": "^2.0.0",
     "tsx": "^4.20.4",
-    "typescript": "^5.5.4"
+    "typescript": "^5.5.4",
+    "vitest": "^1.5.0"
   }
 }

--- a/src/mocks/sampleOutputs.ts
+++ b/src/mocks/sampleOutputs.ts
@@ -1,0 +1,23 @@
+import type { NodeOut, WallOut, DimensionOut, RoomOut } from '../schema.js';
+
+export function makeMockRect(): { nodes: NodeOut[]; walls: WallOut[]; dimensions: DimensionOut[]; rooms: RoomOut[] } {
+  const nodes: NodeOut[] = [
+    { id: 1, xFt: 0, yFt: 0 },
+    { id: 2, xFt: 48, yFt: 0 },
+    { id: 3, xFt: 48, yFt: 30 },
+    { id: 4, xFt: 0, yFt: 30 },
+  ];
+  const walls: WallOut[] = [
+    { id: 1, startId: 1, endId: 2, thicknessInches: 6 },
+    { id: 2, startId: 2, endId: 3, thicknessInches: 6 },
+    { id: 3, startId: 3, endId: 4, thicknessInches: 6 },
+    { id: 4, startId: 4, endId: 1, thicknessInches: 6 },
+  ];
+  const dimensions: DimensionOut[] = [
+    { id: 1, text: "48'-0\"", valueFt: 48, p1Ft: { x: 0, y: 0 }, p2Ft: { x: 48, y: 0 }, type: 'overall' },
+    { id: 2, text: "30'-0\"", valueFt: 30, p1Ft: { x: 48, y: 0 }, p2Ft: { x: 48, y: 30 }, type: 'overall' },
+  ];
+  const rooms: RoomOut[] = [];
+  return { nodes, walls, dimensions, rooms };
+}
+

--- a/src/parse/detectScale.ts
+++ b/src/parse/detectScale.ts
@@ -1,0 +1,18 @@
+import type { TextItem } from './readPdf.js';
+import type { ScaleInfo } from '../schema.js';
+
+export function detectScale({ textItems, pdfUnitsPerInch }: { textItems: TextItem[]; pdfUnitsPerInch: number }): ScaleInfo {
+  const allText = textItems.map(t => t.text.toUpperCase()).join(' ');
+  const match = allText.match(/SCALE\s*:?\s*(\d+(?:\.\d+)?)\s*\/\s*(\d+(?:\.\d+)?)\s*"?\s*=\s*1['′]?/);
+  if (match) {
+    const num = parseFloat(match[1]);
+    const den = parseFloat(match[2]);
+    if (num > 0) {
+      const inchesPerFoot = den / num;
+      const pdfUnitsPerFoot = inchesPerFoot * pdfUnitsPerInch;
+      return { feetPerPdfUnit: 1 / pdfUnitsPerFoot, pdfUnitsPerFoot, source: 'sheet' };
+    }
+  }
+  return { feetPerPdfUnit: 1 / 864, pdfUnitsPerFoot: 864, source: 'default', note: 'no explicit sheet scale found' };
+}
+

--- a/src/parse/extractVectors.ts
+++ b/src/parse/extractVectors.ts
@@ -1,0 +1,92 @@
+import { OPS } from 'pdfjs-dist';
+import type { TextItem } from './readPdf.js';
+
+export interface LinePdf {
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+  width: number;
+}
+
+export interface DimText {
+  text: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export function extractVectors({ opList, textItems }: { opList: any; textItems: TextItem[] }): {
+  wallLinesPdf: LinePdf[];
+  dimText: DimText[];
+} {
+  const wallLinesPdf: LinePdf[] = [];
+  let currentPoint: { x: number; y: number } | null = null;
+  let path: LinePdf[] = [];
+  let lineWidth = 0;
+  for (let i = 0; i < opList.fnArray.length; i++) {
+    const fn = opList.fnArray[i];
+    const args = opList.argsArray[i];
+    switch (fn) {
+      case OPS.setLineWidth:
+        lineWidth = args[0];
+        break;
+      case OPS.moveTo:
+        currentPoint = { x: args[0], y: args[1] };
+        break;
+      case OPS.lineTo:
+        if (currentPoint) {
+          path.push({ x1: currentPoint.x, y1: currentPoint.y, x2: args[0], y2: args[1], width: lineWidth });
+          currentPoint = { x: args[0], y: args[1] };
+        }
+        break;
+      case OPS.rectangle: {
+        const [x, y, w, h] = args;
+        path.push({ x1: x, y1: y, x2: x + w, y2: y, width: lineWidth });
+        path.push({ x1: x + w, y1: y, x2: x + w, y2: y + h, width: lineWidth });
+        path.push({ x1: x + w, y1: y + h, x2: x, y2: y + h, width: lineWidth });
+        path.push({ x1: x, y1: y + h, x2: x, y2: y, width: lineWidth });
+        break;
+      }
+      case OPS.closePath:
+        if (currentPoint && path.length) {
+          const first = path[0];
+          path.push({ x1: currentPoint.x, y1: currentPoint.y, x2: first.x1, y2: first.y1, width: lineWidth });
+        }
+        break;
+      case OPS.stroke:
+      case OPS.closeStroke:
+      case OPS.stroke:
+      case OPS.closeStroke:
+      case OPS.fillStroke:
+      case OPS.closeFillStroke:
+      case OPS.eoFillStroke:
+      case OPS.closeEOFillStroke:
+        for (const ln of path) {
+          if (ln.width >= 2) wallLinesPdf.push(ln);
+        }
+        path = [];
+        currentPoint = null;
+        break;
+      case OPS.fill:
+      case OPS.eoFill:
+        path = [];
+        currentPoint = null;
+        break;
+      default:
+        break;
+    }
+  }
+
+  const dimText: DimText[] = [];
+  for (const t of textItems) {
+    if (t.text.includes("'") || t.text.includes('"')) {
+      const x = t.transform[4];
+      const y = t.transform[5];
+      dimText.push({ text: t.text, x, y, width: t.width, height: t.height });
+    }
+  }
+  return { wallLinesPdf, dimText };
+}
+

--- a/src/parse/parseFloorplan.ts
+++ b/src/parse/parseFloorplan.ts
@@ -1,69 +1,26 @@
+import type { ParseArgs, ParseResponse } from '../schema.js';
+import { readPdf } from './readPdf.js';
+import { detectScale } from './detectScale.js';
+import { extractVectors } from './extractVectors.js';
+import { resolveDims } from './resolveDims.js';
+import { topology } from './topology.js';
+import { toJson } from './toJson.js';
 
-import type { ParseArgs, ParseResponse, NodeOut, WallOut, DimensionOut } from '../schema.js';
-import { loadPdfDoc } from './loadPdf.js';
-import { extractPathsAndTexts } from './extract.js';
-import { detectScale } from './scale.js';
-import { classifyStrokes } from './classify.js';
-import { buildGraph } from './graph.js';
-import { extractDimensions } from './dimensions.js';
-
-/**
- * Orchestrates the full pipeline. This returns a valid ParseResponse even while
- * parts are TODO — currently includes a small mock so your app can integrate.
- */
 export async function parseFloorplan(args: ParseArgs): Promise<ParseResponse> {
-  // 1) Load PDF
-  const doc = await loadPdfDoc(args.pdfPath);
-
-  // 2) Extract vectors + text from the chosen page
-  const { paths, texts, pdfUnitsPerInch } = await extractPathsAndTexts(doc, args.page);
-
-  // 3) Detect scale (using sheet scale text or a known dimension measurement)
-  const scale = detectScale({ texts, pdfUnitsPerInch });
-
-  // 4) Separate walls vs annotations
-  const { wallStrokes, annoStrokes, fills } = classifyStrokes({ paths });
-
-  // 5) Build wall centerline graph
-  const { nodes, walls } = buildGraph({ wallStrokes, fills, scale });
-
-  // 6) Extract and associate dimension strings
-  const dimensions = extractDimensions({ texts, scale, nodes, walls });
-
-  // --- TEMP MOCK FALLBACK if nothing detected yet ---
-  const hasAny = nodes.length > 0 && walls.length > 0;
-  if (!hasAny) {
-    const mockNodes: NodeOut[] = [
-      { id: 101, xFt: 0, yFt: 0 },
-      { id: 102, xFt: 48, yFt: 0 },
-      { id: 103, xFt: 48, yFt: 30 },
-      { id: 104, xFt: 0, yFt: 30 },
-    ];
-    const mockWalls: WallOut[] = [
-      { id: 201, startId: 101, endId: 102, thicknessInches: 6 },
-      { id: 202, startId: 102, endId: 103, thicknessInches: 6 },
-      { id: 203, startId: 103, endId: 104, thicknessInches: 6 },
-      { id: 204, startId: 104, endId: 101, thicknessInches: 6 },
-    ];
-    const mockDims: DimensionOut[] = [
-      { id: 301, text: "48'-0\"", valueFt: 48, p1Ft: { x: 0, y: 0 }, p2Ft: { x: 48, y: 0 }, type: 'overall' }
-    ];
-    return {
-      units: 'ft',
-      scale,
-      nodes: mockNodes,
-      walls: mockWalls,
-      dimensions: mockDims,
-      rooms: []
-    };
-  }
-
-  return {
-    units: 'ft',
+  const page = await readPdf(args.pdfPath, args.page);
+  const textItems = await page.extractTextItems();
+  const scale = detectScale({ textItems, pdfUnitsPerInch: page.pdfUnitsPerInch });
+  const opList = await page.getOperatorList();
+  const vectors = extractVectors({ opList, textItems });
+  const dimRes = resolveDims({ dimText: vectors.dimText, wallLinesPdf: vectors.wallLinesPdf, scale });
+  const topo = topology({ wallLinesPdf: vectors.wallLinesPdf, scale });
+  return toJson({
     scale,
-    nodes,
-    walls,
-    dimensions,
-    rooms: [] // TODO
-  };
+    nodes: topo.nodes,
+    walls: topo.walls,
+    rooms: topo.rooms,
+    dimensions: dimRes.dimensions,
+    warnings: [...dimRes.warnings, ...topo.warnings],
+  });
 }
+

--- a/src/parse/readPdf.ts
+++ b/src/parse/readPdf.ts
@@ -1,0 +1,43 @@
+import { getDocument, GlobalWorkerOptions } from 'pdfjs-dist';
+
+GlobalWorkerOptions.workerSrc = undefined as any;
+
+export interface TextItem {
+  text: string;
+  transform: number[];
+  width: number;
+  height: number;
+}
+
+export interface PdfPageInfo {
+  width: number;
+  height: number;
+  pdfUnitsPerInch: number;
+  getOperatorList: () => Promise<any>;
+  getTextContent: () => Promise<any>;
+  extractTextItems: () => Promise<TextItem[]>;
+}
+
+export async function readPdf(pdfPath: string, pageNumber?: number): Promise<PdfPageInfo> {
+  const loadingTask = getDocument(pdfPath);
+  const doc = await loadingTask.promise;
+  const pageIdx = pageNumber && pageNumber > 0 ? pageNumber : 1;
+  const page = await doc.getPage(pageIdx);
+  const view = page.view;
+  const width = view[2] - view[0];
+  const height = view[3] - view[1];
+  const pdfUnitsPerInch = 72 * (page.userUnit || 1);
+  const getOperatorList = () => page.getOperatorList();
+  const getTextContent = () => page.getTextContent();
+  const extractTextItems = async (): Promise<TextItem[]> => {
+    const tc = await getTextContent();
+    return tc.items.map((it: any) => ({
+      text: it.str,
+      transform: it.transform,
+      width: it.width,
+      height: 'height' in it ? it.height : it.fontHeight || 0,
+    }));
+  };
+  return { width, height, pdfUnitsPerInch, getOperatorList, getTextContent, extractTextItems };
+}
+

--- a/src/parse/resolveDims.ts
+++ b/src/parse/resolveDims.ts
@@ -1,0 +1,70 @@
+import type { DimText, LinePdf } from './extractVectors.js';
+import type { ScaleInfo, DimensionOut } from '../schema.js';
+
+interface ResolveResult {
+  dimensions: DimensionOut[];
+  warnings: string[];
+}
+
+export function resolveDims({ dimText, wallLinesPdf, scale }: { dimText: DimText[]; wallLinesPdf: LinePdf[]; scale: ScaleInfo }): ResolveResult {
+  const dimensions: DimensionOut[] = [];
+  const warnings: string[] = [];
+  let id = 1;
+  for (const dt of dimText) {
+    const valueFt = parseDim(dt.text);
+    if (valueFt == null) continue;
+    const center = { x: dt.x + dt.width / 2, y: dt.y + dt.height / 2 };
+    let best: LinePdf | undefined;
+    let bestDist = Infinity;
+    for (const line of wallLinesPdf) {
+      const dist = pointToSegmentDistance(center, line);
+      if (dist < bestDist) {
+        bestDist = dist;
+        best = line;
+      }
+    }
+    if (!best) {
+      warnings.push(`no wall line found for dimension "${dt.text}"`);
+      continue;
+    }
+    dimensions.push({
+      id: id++,
+      text: dt.text,
+      valueFt,
+      p1Ft: { x: best.x1 * scale.feetPerPdfUnit, y: best.y1 * scale.feetPerPdfUnit },
+      p2Ft: { x: best.x2 * scale.feetPerPdfUnit, y: best.y2 * scale.feetPerPdfUnit },
+      type: 'overall',
+    });
+  }
+  return { dimensions, warnings };
+}
+
+function parseDim(text: string): number | null {
+  const m = text.match(/(\d+)\s*'\s*-?\s*(\d+)?/);
+  if (!m) return null;
+  const feet = parseInt(m[1], 10);
+  const inches = m[2] ? parseInt(m[2], 10) : 0;
+  return feet + inches / 12;
+}
+
+function pointToSegmentDistance(p: { x: number; y: number }, l: LinePdf): number {
+  const { x1, y1, x2, y2 } = l;
+  const A = p.x - x1;
+  const B = p.y - y1;
+  const C = x2 - x1;
+  const D = y2 - y1;
+  const dot = A * C + B * D;
+  const lenSq = C * C + D * D;
+  let param = lenSq !== 0 ? dot / lenSq : -1;
+  if (param < 0) {
+    param = 0;
+  } else if (param > 1) {
+    param = 1;
+  }
+  const xx = x1 + param * C;
+  const yy = y1 + param * D;
+  const dx = p.x - xx;
+  const dy = p.y - yy;
+  return Math.sqrt(dx * dx + dy * dy);
+}
+

--- a/src/parse/toJson.ts
+++ b/src/parse/toJson.ts
@@ -1,0 +1,28 @@
+import type { ScaleInfo, NodeOut, WallOut, RoomOut, DimensionOut, ParseResponse } from '../schema.js';
+import { makeMockRect } from '../mocks/sampleOutputs.js';
+
+interface ToJsonArgs {
+  scale: ScaleInfo;
+  nodes: NodeOut[];
+  walls: WallOut[];
+  rooms: RoomOut[];
+  dimensions: DimensionOut[];
+  warnings: string[];
+}
+
+export function toJson({ scale, nodes, walls, rooms, dimensions, warnings }: ToJsonArgs): ParseResponse {
+  if (nodes.length === 0 || walls.length === 0) {
+    const mock = makeMockRect();
+    return {
+      units: 'ft',
+      scale,
+      nodes: mock.nodes,
+      walls: mock.walls,
+      dimensions: mock.dimensions,
+      rooms: mock.rooms,
+      warnings: [...warnings, 'returned mock rectangle'],
+    };
+  }
+  return { units: 'ft', scale, nodes, walls, dimensions, rooms, warnings };
+}
+

--- a/src/parse/topology.ts
+++ b/src/parse/topology.ts
@@ -1,0 +1,49 @@
+import type { LinePdf } from './extractVectors.js';
+import type { ScaleInfo, NodeOut, WallOut, RoomOut } from '../schema.js';
+
+interface TopologyResult {
+  nodes: NodeOut[];
+  walls: WallOut[];
+  rooms: RoomOut[];
+  warnings: string[];
+}
+
+export function topology({ wallLinesPdf, scale }: { wallLinesPdf: LinePdf[]; scale: ScaleInfo }): TopologyResult {
+  const nodes: NodeOut[] = [];
+  const walls: WallOut[] = [];
+  const rooms: RoomOut[] = [];
+  const warnings: string[] = [];
+
+  const epsilon = 0.2; // feet
+  let nextNodeId = 1;
+  let nextWallId = 1;
+
+  function snap(xFt: number, yFt: number): number {
+    for (const n of nodes) {
+      const dx = n.xFt - xFt;
+      const dy = n.yFt - yFt;
+      if (Math.hypot(dx, dy) <= epsilon) return n.id;
+    }
+    const id = nextNodeId++;
+    nodes.push({ id, xFt, yFt });
+    return id;
+  }
+
+  const wallSet = new Set<string>();
+  for (const ln of wallLinesPdf) {
+    const x1Ft = ln.x1 * scale.feetPerPdfUnit;
+    const y1Ft = ln.y1 * scale.feetPerPdfUnit;
+    const x2Ft = ln.x2 * scale.feetPerPdfUnit;
+    const y2Ft = ln.y2 * scale.feetPerPdfUnit;
+    const id1 = snap(x1Ft, y1Ft);
+    const id2 = snap(x2Ft, y2Ft);
+    if (id1 === id2) continue;
+    const key = id1 < id2 ? `${id1}-${id2}` : `${id2}-${id1}`;
+    if (wallSet.has(key)) continue;
+    wallSet.add(key);
+    walls.push({ id: nextWallId++, startId: id1, endId: id2, thicknessInches: ln.width / scale.pdfUnitsPerFoot * 12 });
+  }
+
+  return { nodes, walls, rooms, warnings };
+}
+

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -32,6 +32,7 @@ export interface RoomOut {
 export interface ScaleInfo {
   feetPerPdfUnit: number;
   pdfUnitsPerFoot: number;
+  source: string;
   note?: string;
 }
 
@@ -47,4 +48,5 @@ export interface ParseResponse {
   walls: WallOut[];
   dimensions: DimensionOut[];
   rooms: RoomOut[];
+  warnings: string[];
 }

--- a/src/test/parseFloorplan.test.ts
+++ b/src/test/parseFloorplan.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { parseFloorplan } from '../parse/parseFloorplan.js';
+import { PDFDocument } from 'pdf-lib';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { writeFileSync } from 'node:fs';
+
+describe('parseFloorplan', () => {
+  it('returns mock rectangle when no vectors detected', async () => {
+    const pdf = await PDFDocument.create();
+    pdf.addPage([300, 300]);
+    const bytes = await pdf.save();
+    const file = join(tmpdir(), 'blank.pdf');
+    writeFileSync(file, bytes);
+    const result = await parseFloorplan({ pdfPath: file });
+    expect(result.nodes.length).toBe(4);
+    expect(result.walls.length).toBe(4);
+    expect(result.dimensions.length).toBeGreaterThan(0);
+    expect(result.warnings).toContain('returned mock rectangle');
+  });
+});
+

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,0 +1,2 @@
+declare module 'cors';
+declare module 'vitest';

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+});
+


### PR DESCRIPTION
## Summary
- add PDF reading, scale detection, vector extraction, dimension resolving, topology, and JSON normalization modules
- provide mock rectangle output for development and tests
- set up Vitest configuration and initial test harness

## Testing
- `npm run build`
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c04807348832f8ca9a54f51864f52