### PR TITLE
Use pdfjs legacy build

### DIFF
--- a/src/parse/loadPdf.ts
+++ b/src/parse/loadPdf.ts
@@ -1,12 +1,15 @@
+import * as pdfjs from 'pdfjs-dist/legacy/build/pdf.mjs';
+import { promises as fs } from 'fs';
+
+(pdfjs as any).disableWorker = true;
 
 /**
- * PDF loader stub
+ * Load a PDF document using pdfjs-dist
  *
- * In production, use pdfjs-dist to open the PDF and hand a document proxy to extract.ts.
  * Kept separate so you can swap in pdf-lib or a native bridge later.
  */
-export async function loadPdfDoc(pdfPath: string): Promise<any> {
-  // TODO: implement real pdfjs-dist load here.
-  // For now we just return the file path; extract.ts will know what to do (mock).
-  return { pdfPath };
+export async function loadPdfDoc(pdfPath: string): Promise<pdfjs.PDFDocumentProxy> {
+  const data = await fs.readFile(pdfPath);
+  const loadingTask = pdfjs.getDocument({ data });
+  return loadingTask.promise;
 }

--- a/src/types/cors.d.ts
+++ b/src/types/cors.d.ts
@@ -1,0 +1,1 @@
+declare module 'cors';

--- a/src/types/pdfjs.d.ts
+++ b/src/types/pdfjs.d.ts
@@ -1,0 +1,3 @@
+declare module 'pdfjs-dist/legacy/build/pdf.mjs' {
+  export * from 'pdfjs-dist';
+}


### PR DESCRIPTION
## Summary
- switch pdfjs import to legacy build and disable workers
- add ambient module declarations for pdfjs legacy build and cors

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c0b021098832fabf6a35c5cd149b2